### PR TITLE
feat:마이페이지 회원 탈퇴 연동

### DIFF
--- a/api/user.ts
+++ b/api/user.ts
@@ -1,4 +1,5 @@
 import axiosInstance from "@/lib/axiosInstance";
+import * as SecureStore from "expo-secure-store";
 
 export const joinUser = async (body: {
   surName: string;
@@ -6,8 +7,21 @@ export const joinUser = async (body: {
   koreanName: string;
   birth: string;
   nationality: string;
-  alarm: boolean; 
+  alarm: boolean;
 }) => {
-  const res = await axiosInstance.post("/api/auth/join", body);
+  const token = await SecureStore.getItemAsync("access_token");
+
+  console.log("[JOIN USER BODY]", body);
+  console.log("[JOIN USER TOKEN]", token);
+
+  const res = await axiosInstance.post("/api/auth/join", body, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  console.log("[JOIN USER SUCCESS]", res.data);
+
   return res.data;
 };

--- a/app/(auth)/kakao-webview.tsx
+++ b/app/(auth)/kakao-webview.tsx
@@ -1,22 +1,25 @@
-import { useAuth } from "@/context/authContext";
 import axiosInstance from "@/lib/axiosInstance";
 import { Colors } from "@/styles/colors";
 import { typography } from "@/styles/typography";
 import { useRouter } from "expo-router";
 import * as SecureStore from "expo-secure-store";
 import React, { useMemo, useRef, useState } from "react";
-import { ActivityIndicator, Pressable, StyleSheet, Text, View } from "react-native";
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
 import { WebView } from "react-native-webview";
 
 export default function KakaoWebView() {
   const router = useRouter();
-  const { checkAuth } = useAuth();
 
   const REST_API_KEY = process.env.EXPO_PUBLIC_REST_API_KEY;
   const REDIRECT_URI = process.env.EXPO_PUBLIC_REDIRECT_URI;
 
   const webviewRef = useRef<WebView>(null);
-
   const inflightRef = useRef(false);
   const lastCodeRef = useRef<string | null>(null);
 
@@ -30,7 +33,8 @@ export default function KakaoWebView() {
       `https://kauth.kakao.com/oauth/authorize` +
       `?client_id=${encodeURIComponent(REST_API_KEY)}` +
       `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}` +
-      `&response_type=code`
+      `&response_type=code` +
+      `&prompt=login`
     );
   }, [REST_API_KEY, REDIRECT_URI]);
 
@@ -41,11 +45,18 @@ export default function KakaoWebView() {
 
       router.replace("/(tabs)");
     } catch (e: any) {
-      console.error("로그인 후 /me 실패:", e?.response?.data);
+      console.log("로그인 후 /me 실패:", e?.response?.data);
 
+      const status = e?.response?.status;
       const message = e?.response?.data?.message ?? "";
 
-      if (message.includes("회원 정보 입력을 완료해주세요")) {
+      const needsProfileSetup =
+        status === 400 &&
+        (message.includes("회원 정보 입력을 완료해주세요") ||
+          message.includes("회원정보 입력을 완료해주세요") ||
+          message.includes("회원 정보"));
+
+      if (needsProfileSetup) {
         router.replace("/onboarding/profile-setup");
         return;
       }
@@ -76,15 +87,17 @@ export default function KakaoWebView() {
 
       console.log("[KAKAO] backend response:", res?.data);
 
+      const data = res.data?.data;
+
       const tokenRaw =
-        res.data?.data?.accessToken ??
-        res.data?.data?.jwtAccessToken ??
+        data?.accessToken ??
+        data?.jwtAccessToken ??
         res.data?.accessToken ??
         res.data?.jwtAccessToken;
 
-      const refreshTokenRaw =
-        res.data?.data?.refreshToken ??
-        res.data?.refreshToken;
+      const refreshTokenRaw = data?.refreshToken ?? res.data?.refreshToken;
+
+      const registered = data?.registered;
 
       if (!tokenRaw) {
         setFatalError("서버 응답에 accessToken이 없음 (응답 스키마 확인 필요)");
@@ -93,17 +106,21 @@ export default function KakaoWebView() {
 
       const token = String(tokenRaw).replace(/^Bearer\s+/i, "");
       console.log("[KAKAO] final access token:", token);
+      console.log("[KAKAO] registered:", registered);
 
       await SecureStore.setItemAsync("access_token", token);
 
       if (refreshTokenRaw) {
         await SecureStore.setItemAsync("refresh_token", String(refreshTokenRaw));
-        console.log("[KAKAO] refresh token saved");
       } else {
-        console.log("[KAKAO] refresh token 없음");
+        await SecureStore.deleteItemAsync("refresh_token");
       }
 
-      await checkAuth();
+      if (registered === false) {
+        router.replace("/onboarding/profile-setup");
+        return;
+      }
+
       await routeAfterLogin();
     } catch (e: any) {
       console.log("[AUTH] FAIL:", {
@@ -182,20 +199,18 @@ export default function KakaoWebView() {
         source={{ uri: authUrl }}
         originWhitelist={["*"]}
         cacheEnabled={false}
+        incognito={true}
         javaScriptEnabled
         startInLoadingState
         onShouldStartLoadWithRequest={(req) => {
           const url = req.url;
 
           if (REDIRECT_URI && url.startsWith(REDIRECT_URI)) {
-            console.log("[KAKAO REDIRECT URL]", url);
-
             webviewRef.current?.stopLoading?.();
 
             try {
               const current = new URL(url);
               const code = current.searchParams.get("code");
-              console.log("[KAKAO] parsed code:", code);
 
               if (code) {
                 handleCodeOnce(code);

--- a/app/(tabs)/settings/index.tsx
+++ b/app/(tabs)/settings/index.tsx
@@ -16,11 +16,10 @@ import {
 
 const MENU_ITEMS = [
   { label: "개인정보 수정", action: "edit_profile" as const },
-  { label: "보관된 여행 및 일기 관리", route: "/settings/archive" },
-  { label: "알림 설정", route: "/settings/notification" },
+  { label: "보관된 여행 및 일기 관리", route: "/(tabs)/settings/archive" },
+  { label: "알림 설정", route: "/(tabs)/settings/notification" },
   { label: "로그아웃", action: "logout" as const },
-  { label: "회원탈퇴", route: "/settings/withdraw" },
-  { label: "권한 설정", route: "/settings/permission" },
+  { label: "회원탈퇴", route: "/(tabs)/settings/withdraw" },
 ];
 
 export default function SettingsScreen() {

--- a/app/(tabs)/settings/notification.tsx
+++ b/app/(tabs)/settings/notification.tsx
@@ -1,0 +1,105 @@
+import SettingsBackIcon from "@/assets/images/back_button.svg";
+import { Colors } from "@/styles/colors";
+import { typography } from "@/styles/typography";
+import { useRouter } from "expo-router";
+import React from "react";
+import {
+    Linking,
+    Pressable,
+    StyleSheet,
+    Text,
+    View
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+export default function NotificationScreen() {
+  const router = useRouter();
+
+  const openAppSettings = () => {
+    Linking.openSettings();
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.inner}>
+        <View style={styles.header}>
+          <Pressable
+            onPress={() => router.push("/(tabs)/settings")}
+            style={styles.backButton}
+            hitSlop={12}
+          >
+            <SettingsBackIcon width={28} height={28} />
+          </Pressable>
+
+          <Text style={styles.headerTitle}>알림 설정</Text>
+        </View>
+
+        <View style={styles.listSection}>
+          <Pressable style={styles.menuRow} onPress={openAppSettings}>
+            <Text style={styles.menuText}>알림 권한</Text>
+            <View style={styles.divider} />
+          </Pressable>
+
+          <Pressable style={styles.menuRow} onPress={openAppSettings}>
+            <Text style={styles.menuText}>위치 권한 설정</Text>
+            <View style={styles.divider} />
+          </Pressable>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+  flex: 1,
+  backgroundColor: Colors.primary50,
+},
+
+inner: {
+  flex: 1,
+  paddingHorizontal: 20,
+  paddingTop: 14, 
+},
+
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingBottom: 34,
+  },
+
+  backButton: {
+    width: 32,
+    height: 32,
+    justifyContent: "center",
+    alignItems: "flex-start",
+    marginRight: 6,
+  },
+
+  headerTitle: {
+    ...typography.head4_22_regular,
+    color: "#161616",
+    fontSize: 26,
+  },
+
+  listSection: {
+    paddingHorizontal: 8,
+  },
+
+  menuRow: {
+    paddingTop: 20,
+  },
+
+  menuText: {
+    ...typography.body2_18_regular,
+    color: "#535353",
+    fontSize: 24,
+    marginBottom: 22,
+  },
+
+  divider: {
+    width: "100%",
+    height: 1,
+    backgroundColor: "#D9D1C3",
+  },
+});

--- a/app/(tabs)/settings/withdraw.tsx
+++ b/app/(tabs)/settings/withdraw.tsx
@@ -1,0 +1,224 @@
+import SettingsBackIcon from "@/assets/images/back_button.svg";
+import { useAuth } from "@/context/authContext";
+import axiosInstance from "@/lib/axiosInstance";
+import { Colors } from "@/styles/colors";
+import { typography } from "@/styles/typography";
+import { useFocusEffect, useRouter } from "expo-router";
+import * as SecureStore from "expo-secure-store";
+import React, { useCallback, useState } from "react";
+import {
+    ActivityIndicator,
+    Modal,
+    Pressable,
+    SafeAreaView,
+    StyleSheet,
+    Text,
+    View,
+} from "react-native";
+
+export default function WithdrawScreen() {
+  const router = useRouter();
+  const { logout } = useAuth();
+
+  const [isModalVisible, setIsModalVisible] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useFocusEffect(
+    useCallback(() => {
+      setIsModalVisible(true);
+      return () => {};
+    }, [])
+  );
+
+  const handleWithdraw = async () => {
+    if (isSubmitting) return;
+
+    try {
+      setIsSubmitting(true);
+
+      const token = await SecureStore.getItemAsync("access_token");
+      console.log("[WITHDRAW TOKEN]", token);
+
+      const res = await axiosInstance.delete("/api/users/me");
+      console.log("[WITHDRAW SUCCESS]", res.data);
+
+      await logout();
+
+      router.replace("/onboarding");
+    } catch (e: any) {
+      console.log("[WITHDRAW] 회원탈퇴 실패");
+      console.log("[WITHDRAW] 응답 상태:", e?.response?.status);
+      console.log("[WITHDRAW] 응답 데이터:", e?.response?.data);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setIsModalVisible(false);
+    router.back();
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.inner}>
+        <View style={styles.header}>
+          <Pressable
+            onPress={() => router.back()}
+            style={styles.backButton}
+            hitSlop={12}
+          >
+            <SettingsBackIcon width={28} height={28} />
+          </Pressable>
+
+          <Text style={styles.headerTitle}>설정</Text>
+        </View>
+      </View>
+
+      <Modal
+        visible={isModalVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={handleCancel}
+        presentationStyle="overFullScreen"
+      >
+        <View style={styles.modalDim}>
+          <View style={styles.modalBox}>
+            <Text style={styles.modalTitle}>회원 탈퇴</Text>
+
+            <Text style={styles.modalDesc}>
+              정말 회원을 탈퇴하시겠습니까?{"\n"}
+              지금까지의 여행 기록이 모두 사라집니다.
+            </Text>
+
+            <View style={styles.buttonRow}>
+              <Pressable
+                style={[styles.modalButton, styles.withdrawButton]}
+                onPress={handleWithdraw}
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? (
+                  <ActivityIndicator size="small" color={Colors.primary900} />
+                ) : (
+                  <Text style={styles.withdrawButtonText}>탈퇴</Text>
+                )}
+              </Pressable>
+
+              <Pressable
+                style={[styles.modalButton, styles.cancelButton]}
+                onPress={handleCancel}
+                disabled={isSubmitting}
+              >
+                <Text style={styles.cancelButtonText}>취소</Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </Modal>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.primary50,
+  },
+
+  inner: {
+    flex: 1,
+    paddingHorizontal: 20,
+  },
+
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingTop: 14,
+    paddingBottom: 34,
+  },
+
+  backButton: {
+    width: 32,
+    height: 32,
+    justifyContent: "center",
+    alignItems: "flex-start",
+    marginRight: 6,
+  },
+
+  headerTitle: {
+    ...typography.head4_22_regular,
+    color: "#161616",
+    fontSize: 26,
+  },
+
+  modalDim: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.55)",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 32,
+  },
+
+  modalBox: {
+    backgroundColor: "#FFFFFF",
+    paddingTop: 34,
+    paddingHorizontal: 24,
+    paddingBottom: 24,
+    alignItems: "center",
+    width: 296,
+    minHeight: 195,
+    borderRadius: 24,
+  },
+
+  modalTitle: {
+    ...typography.head4_22_regular,
+    color: Colors.primary950,
+    fontSize: 24,
+    marginBottom: 20,
+  },
+
+  modalDesc: {
+    ...typography.body2_18_regular,
+    color: Colors.primary900,
+    fontSize: 18,
+    lineHeight: 26,
+    textAlign: "center",
+    marginBottom: 20,
+  },
+
+  buttonRow: {
+    width: "100%",
+    flexDirection: "row",
+    gap: 12,
+  },
+
+  modalButton: {
+    flex: 1,
+    height: 48,
+    borderRadius: 24,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+
+  withdrawButton: {
+    backgroundColor: "#FFFFFF",
+    borderWidth: 1,
+    borderColor: "#B8AA96",
+  },
+
+  cancelButton: {
+    backgroundColor: Colors.primary900,
+  },
+
+  withdrawButtonText: {
+    ...typography.body2_18_regular,
+    color: "#8A7B66",
+    fontSize: 18,
+  },
+
+  cancelButtonText: {
+    ...typography.body2_18_regular,
+    color: Colors.primary50,
+    fontSize: 18,
+  },
+});

--- a/components/features/onboarding/OnboardingStep4Screen.tsx
+++ b/components/features/onboarding/OnboardingStep4Screen.tsx
@@ -14,6 +14,7 @@ import {
 } from 'react-native';
 
 import KakaoIcon from '@/assets/images/kakao.svg';
+import * as SecureStore from 'expo-secure-store';
 
 type Step4Props = {
   onFinish: () => void;
@@ -73,10 +74,14 @@ export default function OnboardingStep4Screen({ onFinish }: Step4Props) {
     init();
   }, [checkAuth, router]);
 
-  const handleKakaoStart = () => {
-    if (loading) return;
-    router.push('/(auth)/kakao-webview');
-  };
+ const handleKakaoStart = async () => {
+  if (loading) return;
+
+  await SecureStore.deleteItemAsync('access_token');
+  await SecureStore.deleteItemAsync('refresh_token');
+
+  router.push('/(auth)/kakao-webview');
+};
 
   if (loading) {
     return (

--- a/components/features/onboarding/ProfileSetup.tsx
+++ b/components/features/onboarding/ProfileSetup.tsx
@@ -1,9 +1,8 @@
 import * as ImagePicker from "expo-image-picker";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
-  findNodeHandle,
   Image,
   Keyboard,
   Platform,
@@ -13,13 +12,14 @@ import {
   Text,
   TextInput,
   TouchableWithoutFeedback,
-  UIManager,
   View,
 } from "react-native";
 import DateTimePickerModal from "react-native-modal-datetime-picker";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 import { joinUser } from "@/api/user";
 import UploadIcon from "@/assets/images/Image.svg";
+import BackIcon from "@/assets/images/back_button.svg";
 import axiosInstance from "@/lib/axiosInstance";
 import { Colors } from "@/styles/colors";
 import { typography } from "@/styles/typography";
@@ -36,12 +36,6 @@ export default function ProfileSetup() {
   const router = useRouter();
   const { mode } = useLocalSearchParams<{ mode?: string }>();
   const isEditMode = mode === "edit";
-
-  const scrollRef = useRef<ScrollView | null>(null);
-
-  const nameKoRef = useRef<View | null>(null);
-  const nameEnLastRef = useRef<View | null>(null);
-  const nameEnFirstRef = useRef<View | null>(null);
 
   const [form, setForm] = useState<FormState>({
     photoUri: null,
@@ -81,8 +75,6 @@ export default function ProfileSetup() {
         const res = await axiosInstance.get("/api/users/me");
         const user = res?.data?.data?.user;
 
-        console.log("[PROFILE EDIT] /api/users/me user 응답:", user);
-
         setForm({
           photoUri: user?.profileImageUrl ?? null,
           nameKo: user?.koreanName ?? "",
@@ -91,9 +83,9 @@ export default function ProfileSetup() {
           nameEnFirst: user?.firstName ?? "",
         });
       } catch (e: any) {
-        console.error("[PROFILE EDIT] 기존 정보 불러오기 실패:", e);
-        console.error("[PROFILE EDIT] 응답 상태:", e?.response?.status);
-        console.error("[PROFILE EDIT] 응답 데이터:", e?.response?.data);
+        console.log("[PROFILE EDIT] 기존 정보 불러오기 실패");
+        console.log("응답 상태:", e?.response?.status);
+        console.log("응답 데이터:", e?.response?.data);
       } finally {
         setIsLoadingProfile(false);
       }
@@ -102,30 +94,11 @@ export default function ProfileSetup() {
     fetchMyProfile();
   }, [isEditMode]);
 
-  const scrollToInput = (targetRef: React.RefObject<View | null>) => {
-    const scrollNode = findNodeHandle(scrollRef.current);
-    const targetNode = findNodeHandle(targetRef.current);
-
-    if (!scrollNode || !targetNode) return;
-
-    UIManager.measureLayout(
-      targetNode,
-      scrollNode,
-      () => {},
-      (_x, y) => {
-        scrollRef.current?.scrollTo({
-          y: Math.max(0, y - 120),
-          animated: true,
-        });
-      }
-    );
-  };
-
   const onPickImage = async () => {
     const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
 
     if (status !== "granted") {
-      console.error("갤러리 권한이 거부되었다.");
+      console.log("갤러리 권한이 거부되었다.");
       return;
     }
 
@@ -167,25 +140,17 @@ export default function ProfileSetup() {
       };
 
       if (isEditMode) {
-        console.log("회원정보 수정 요청:", payload);
-
-        const res = await axiosInstance.patch("/api/users/me", payload);
-
-        console.log("회원정보 수정 성공:", res?.data);
+        await axiosInstance.patch("/api/users/me", payload);
         router.back();
         return;
       }
 
-      console.log("회원가입 요청:", payload);
-
-      const res = await joinUser(payload);
-
-      console.log("회원가입 성공:", res);
+      await joinUser(payload);
       router.replace("/(tabs)");
     } catch (e: any) {
-      console.error(isEditMode ? "회원정보 수정 실패:" : "회원가입 실패:", e);
-      console.error("응답 상태:", e?.response?.status);
-      console.error("응답 데이터:", e?.response?.data);
+      console.log(isEditMode ? "회원정보 수정 실패" : "회원가입 실패");
+      console.log("응답 상태:", e?.response?.status);
+      console.log("응답 데이터:", e?.response?.data);
     } finally {
       setIsSubmitting(false);
     }
@@ -193,7 +158,7 @@ export default function ProfileSetup() {
 
   if (isLoadingProfile) {
     return (
-      <View style={styles.loadingContainer}>
+      <View style={[styles.loadingContainer, styles.editBackground]}>
         <ActivityIndicator size="large" color={Colors.primary900} />
         <Text style={styles.loadingText}>기존 정보를 불러오는 중...</Text>
       </View>
@@ -201,148 +166,207 @@ export default function ProfileSetup() {
   }
 
   return (
-    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-      <View style={styles.container}>
-        <View style={styles.bg} />
-        <View style={styles.bgOverlay} />
-
-        <ScrollView
-          ref={scrollRef}
-          contentContainerStyle={styles.scrollContent}
-          keyboardShouldPersistTaps="handled"
-          keyboardDismissMode="interactive"
-          showsVerticalScrollIndicator={false}
-        >
-          <Text style={styles.title}>
-            {isEditMode ? "프로필을 수정해주세요!" : "프로필을 입력해주세요!"}
-          </Text>
-
-          <View style={styles.photoWrap}>
-            {!form.photoUri ? (
-              <Pressable style={styles.photoEmpty} onPress={onPickImage}>
-                <UploadIcon width={26} height={26} />
-                <Text style={styles.photoHint}>터치해서 사진 업로드</Text>
-              </Pressable>
-            ) : (
-              <View style={styles.photoFilled}>
-                <Image source={{ uri: form.photoUri }} style={styles.photo} />
-                <Pressable style={styles.photoRemoveBtn} onPress={onRemoveImage}>
-                  <Text style={styles.photoRemoveText}>×</Text>
-                </Pressable>
-              </View>
-            )}
-          </View>
-
-          <View style={styles.formWrap}>
-            <View style={styles.row}>
-              <View style={styles.col} ref={nameKoRef} collapsable={false}>
-                <Text style={styles.label}>한글 성명</Text>
-                <View style={styles.inputBox}>
-                  <TextInput
-                    value={form.nameKo}
-                    onChangeText={(t) => setForm((p) => ({ ...p, nameKo: t }))}
-                    placeholder="한글 성명을 입력해주세요."
-                    placeholderTextColor={Colors.grey500}
-                    style={styles.input}
-                    returnKeyType="next"
-                    onFocus={() => scrollToInput(nameKoRef)}
-                  />
-                </View>
-              </View>
-
-              <View style={styles.col}>
-                <Text style={styles.label}>생년 월일</Text>
-                <Pressable
-                  style={styles.dateBox}
-                  onPress={() => setIsDateOpen(true)}
-                >
-                  <Text
-                    style={[
-                      styles.dateText,
-                      !form.birthDate && { color: Colors.grey500 },
-                    ]}
-                    numberOfLines={1}
-                    ellipsizeMode="tail"
-                  >
-                    {birthText}
-                  </Text>
-                </Pressable>
-              </View>
-            </View>
-
-            <View style={styles.row}>
-              <View style={styles.col} ref={nameEnLastRef} collapsable={false}>
-                <Text style={styles.label}>영문 성</Text>
-                <View style={styles.inputBox}>
-                  <TextInput
-                    value={form.nameEnLast}
-                    onChangeText={(t) =>
-                      setForm((p) => ({ ...p, nameEnLast: t.toUpperCase() }))
-                    }
-                    placeholder="ex) KIM"
-                    placeholderTextColor={Colors.grey500}
-                    autoCapitalize="characters"
-                    style={styles.input}
-                    returnKeyType="next"
-                    onFocus={() => scrollToInput(nameEnLastRef)}
-                  />
-                </View>
-              </View>
-
-              <View style={styles.col} ref={nameEnFirstRef} collapsable={false}>
-                <Text style={styles.label}>영문 이름</Text>
-                <View style={styles.inputBox}>
-                  <TextInput
-                    value={form.nameEnFirst}
-                    onChangeText={(t) =>
-                      setForm((p) => ({ ...p, nameEnFirst: t.toUpperCase() }))
-                    }
-                    placeholder="ex) JI HYE"
-                    placeholderTextColor={Colors.grey500}
-                    autoCapitalize="characters"
-                    style={styles.input}
-                    returnKeyType="done"
-                    onFocus={() => scrollToInput(nameEnFirstRef)}
-                    onSubmitEditing={Keyboard.dismiss}
-                  />
-                </View>
-              </View>
-            </View>
-          </View>
-
-          <View style={styles.scrollBottomSpace} />
-        </ScrollView>
-
-        <View style={styles.bottomWrap}>
-          <Pressable
+    <SafeAreaView
+      style={[
+        styles.safeArea,
+        isEditMode ? styles.editBackground : styles.signupBackground,
+      ]}
+    >
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+        <View style={styles.container}>
+          <View
             style={[
-              styles.startBtn,
-              filled ? styles.startBtnEnabled : styles.startBtnDisabled,
-              isSubmitting && styles.startBtnSubmitting,
+              styles.bg,
+              isEditMode ? styles.editBackground : styles.signupBackground,
             ]}
-            onPress={onSubmit}
-            disabled={!filled || isSubmitting}
+          />
+
+          {!isEditMode && (
+            <Image
+              source={require("@/assets/images/route4.png")}
+              style={styles.routeBg}
+              resizeMode="contain"
+            />
+          )}
+
+          <ScrollView
+            contentContainerStyle={[
+              styles.scrollContent,
+              isEditMode ? styles.editScrollContent : styles.signupScrollContent,
+            ]}
+            keyboardShouldPersistTaps="always"
+            keyboardDismissMode="none"
+            automaticallyAdjustKeyboardInsets={false}
+            showsVerticalScrollIndicator={false}
           >
-            <Text
+            {isEditMode ? (
+              <View style={styles.header}>
+                <Pressable style={styles.backBtn} onPress={() => router.back()}>
+                  <BackIcon width={28} height={28} />
+                </Pressable>
+                <Text style={styles.headerTitle}>설정</Text>
+              </View>
+            ) : (
+              <Text style={styles.title}>프로필을 입력해주세요!</Text>
+            )}
+
+            <View
               style={[
-                styles.startBtnTextBase,
-                filled ? styles.startBtnTextEnabled : styles.startBtnTextDisabled,
+                styles.photoWrap,
+                isEditMode ? styles.editPhotoWrap : styles.signupPhotoWrap,
               ]}
             >
-              {isSubmitting ? "저장 중..." : isEditMode ? "저장하기" : "시작하기"}
-            </Text>
-          </Pressable>
-        </View>
+              {!form.photoUri ? (
+                <Pressable
+                  style={[
+                    styles.photoEmpty,
+                    isEditMode ? styles.editPhotoEmpty : styles.signupPhotoEmpty,
+                  ]}
+                  onPress={onPickImage}
+                >
+                  <UploadIcon width={26} height={26} />
+                  <Text style={styles.photoHint}>터치해서 사진 업로드</Text>
+                </Pressable>
+              ) : (
+                <View
+                  style={[
+                    styles.photoFilled,
+                    isEditMode
+                      ? styles.editPhotoFilled
+                      : styles.signupPhotoFilled,
+                  ]}
+                >
+                  <Image source={{ uri: form.photoUri }} style={styles.photo} />
+                  <Pressable style={styles.photoRemoveBtn} onPress={onRemoveImage}>
+                    <Text style={styles.photoRemoveText}>×</Text>
+                  </Pressable>
+                </View>
+              )}
+            </View>
 
-        <DateTimePickerModal
-          isVisible={isDateOpen}
-          mode="date"
-          onConfirm={onConfirmDate}
-          onCancel={() => setIsDateOpen(false)}
-          maximumDate={new Date()}
-        />
-      </View>
-    </TouchableWithoutFeedback>
+            <View
+              style={[
+                styles.formWrap,
+                isEditMode ? styles.editFormWrap : styles.signupFormWrap,
+              ]}
+            >
+              <View style={styles.row}>
+                <View style={styles.col}>
+                  <Text style={styles.label}>한글 성명</Text>
+                  <View style={styles.inputBox}>
+                    <TextInput
+                      value={form.nameKo}
+                      onChangeText={(t) =>
+                        setForm((p) => ({ ...p, nameKo: t }))
+                      }
+                      placeholder="한글 성명을 입력해주세요."
+                      placeholderTextColor={Colors.grey500}
+                      style={styles.input}
+                      returnKeyType="next"
+                    />
+                  </View>
+                </View>
+
+                <View style={styles.col}>
+                  <Text style={styles.label}>생년 월일</Text>
+                  <Pressable
+                    style={styles.dateBox}
+                    onPress={() => setIsDateOpen(true)}
+                  >
+                    <Text
+                      style={[
+                        styles.dateText,
+                        !form.birthDate && { color: Colors.grey500 },
+                      ]}
+                      numberOfLines={1}
+                      ellipsizeMode="tail"
+                    >
+                      {birthText}
+                    </Text>
+                  </Pressable>
+                </View>
+              </View>
+
+              <View style={styles.row}>
+                <View style={styles.col}>
+                  <Text style={styles.label}>영문 성</Text>
+                  <View style={styles.inputBox}>
+                    <TextInput
+                      value={form.nameEnLast}
+                      onChangeText={(t) =>
+                        setForm((p) => ({
+                          ...p,
+                          nameEnLast: t.toUpperCase(),
+                        }))
+                      }
+                      placeholder="ex) KIM"
+                      placeholderTextColor={Colors.grey500}
+                      autoCapitalize="characters"
+                      style={styles.input}
+                      returnKeyType="next"
+                    />
+                  </View>
+                </View>
+
+                <View style={styles.col}>
+                  <Text style={styles.label}>영문 이름</Text>
+                  <View style={styles.inputBox}>
+                    <TextInput
+                      value={form.nameEnFirst}
+                      onChangeText={(t) =>
+                        setForm((p) => ({
+                          ...p,
+                          nameEnFirst: t.toUpperCase(),
+                        }))
+                      }
+                      placeholder="ex) JI HYE"
+                      placeholderTextColor={Colors.grey500}
+                      autoCapitalize="characters"
+                      style={styles.input}
+                      returnKeyType="done"
+                      onSubmitEditing={Keyboard.dismiss}
+                    />
+                  </View>
+                </View>
+              </View>
+            </View>
+
+            <View style={styles.scrollBottomSpace} />
+          </ScrollView>
+
+          <View style={styles.bottomWrap}>
+            <Pressable
+              style={[
+                styles.startBtn,
+                filled ? styles.startBtnEnabled : styles.startBtnDisabled,
+                isSubmitting && styles.startBtnSubmitting,
+              ]}
+              onPress={onSubmit}
+              disabled={!filled || isSubmitting}
+            >
+              <Text
+                style={[
+                  styles.startBtnTextBase,
+                  filled
+                    ? styles.startBtnTextEnabled
+                    : styles.startBtnTextDisabled,
+                ]}
+              >
+                {isSubmitting ? "저장 중..." : isEditMode ? "저장하기" : "시작하기"}
+              </Text>
+            </Pressable>
+          </View>
+
+          <DateTimePickerModal
+            isVisible={isDateOpen}
+            mode="date"
+            onConfirm={onConfirmDate}
+            onCancel={() => setIsDateOpen(false)}
+            maximumDate={new Date()}
+          />
+        </View>
+      </TouchableWithoutFeedback>
+    </SafeAreaView>
   );
 }
 
@@ -363,13 +387,11 @@ function formatBirthForServer(date: Date) {
 function parseServerBirth(value: string | null) {
   if (!value) return null;
 
-  // 1) 일반적인 YYYY-MM-DD 대응
   const normalDate = new Date(value);
   if (!Number.isNaN(normalDate.getTime())) {
     return normalDate;
   }
 
-  // 2) 예: "22 2월/Feb 2002"
   const match = value.match(/(\d{1,2})\s+\d+월\/[A-Za-z]+\s+(\d{4})/);
 
   if (match) {
@@ -389,45 +411,82 @@ function parseServerBirth(value: string | null) {
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
+  safeArea: { flex: 1 },
+  container: { flex: 1 },
+
+  bg: {
+    ...StyleSheet.absoluteFillObject,
+  },
+
+  signupBackground: {
+    backgroundColor: "#F6F1E9",
+  },
+
+  editBackground: {
+    backgroundColor: Colors.primary50,
+  },
+
+  routeBg: {
+    position: "absolute",
+    width: "120%",
+    height: "78%",
+    left: "-10%",
+    top: 210,
+    opacity: 0.8,
   },
 
   loadingContainer: {
     flex: 1,
-    backgroundColor: "#F3EFE6",
     alignItems: "center",
     justifyContent: "center",
   },
 
   loadingText: {
     ...typography.body2_18_regular,
-    color: Colors.primary950,
+    color: Colors.primary900,
     marginTop: 14,
-  },
-
-  bg: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: "#F3EFE6",
-  },
-
-  bgOverlay: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: Colors.primary150,
-    opacity: 0.12,
   },
 
   scrollContent: {
     paddingHorizontal: 28,
-    paddingTop: 96,
     paddingBottom: 0,
     alignItems: "center",
+  },
+
+  signupScrollContent: {
+    paddingTop: 20,
+  },
+
+  editScrollContent: {
+    paddingTop: 14,
+  },
+
+  header: {
+    width: "100%",
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 28,
+  },
+
+  backBtn: {
+    width: 36,
+    height: 36,
+    alignItems: "flex-start",
+    justifyContent: "center",
+  },
+
+  headerTitle: {
+    ...typography.head3_24_regular,
+    color: "#161616",
+    fontSize: 26,
+    marginLeft: 2,
   },
 
   title: {
     ...typography.head1_28_regular,
     color: "#3B372F",
     letterSpacing: -0.2,
+    marginTop: 6,
     marginBottom: 22,
     textAlign: "center",
     lineHeight: 30,
@@ -436,12 +495,17 @@ const styles = StyleSheet.create({
   photoWrap: {
     width: "100%",
     alignItems: "center",
+  },
+
+  signupPhotoWrap: {
+    marginBottom: 28,
+  },
+
+  editPhotoWrap: {
     marginBottom: 28,
   },
 
   photoEmpty: {
-    width: 233,
-    height: 300,
     borderRadius: 18,
     backgroundColor: "#FFFFFF",
     borderWidth: 1,
@@ -451,19 +515,37 @@ const styles = StyleSheet.create({
     gap: 10,
   },
 
+  signupPhotoEmpty: {
+    width: 233,
+    height: 300,
+  },
+
+  editPhotoEmpty: {
+    width: 292,
+    height: 292,
+  },
+
   photoHint: {
     ...typography.body2_18_regular,
     color: "#817F7C",
   },
 
   photoFilled: {
-    width: 292,
-    height: 292,
     borderRadius: 18,
     overflow: "hidden",
     backgroundColor: "#FFFFFF",
     borderWidth: 1,
     borderColor: "#D8D2C8",
+  },
+
+  signupPhotoFilled: {
+    width: 233,
+    height: 300,
+  },
+
+  editPhotoFilled: {
+    width: 292,
+    height: 292,
   },
 
   photo: {
@@ -493,8 +575,15 @@ const styles = StyleSheet.create({
 
   formWrap: {
     width: "100%",
-    marginTop: 2,
     gap: 22,
+  },
+
+  signupFormWrap: {
+    marginTop: 2,
+  },
+
+  editFormWrap: {
+    marginTop: 2,
   },
 
   row: {

--- a/lib/axiosInstance.ts
+++ b/lib/axiosInstance.ts
@@ -2,25 +2,43 @@ import axios from "axios";
 import * as SecureStore from "expo-secure-store";
 
 const baseURL = "https://voyame-studio.org";
-console.log("BASE URL:", baseURL);
 
 const axiosInstance = axios.create({
   baseURL,
   timeout: 10000,
-  headers: { "Content-Type": "application/json" },
+  headers: {
+    "Content-Type": "application/json",
+  },
 });
 
 axiosInstance.interceptors.request.use(async (config) => {
   const url = config.url ?? "";
 
-  const isAuthRequest =
+  const isPublicAuthRequest =
     url.startsWith("/api/auth/login/kakao") ||
     url.startsWith("/auth/login/kakao");
 
-  if (isAuthRequest) {
+  const isJoinRequest = url.startsWith("/api/auth/join");
+
+  if (isPublicAuthRequest) {
     delete (config.headers as any)?.Authorization;
-  } else {
+  } 
+
+  else if (isJoinRequest) {
     const token = await SecureStore.getItemAsync("access_token");
+
+    console.log("[JOIN TOKEN]", token);
+
+    if (token) {
+      (config.headers as any).Authorization = `Bearer ${token}`;
+    } else {
+      delete (config.headers as any)?.Authorization;
+    }
+  } 
+
+  else {
+    const token = await SecureStore.getItemAsync("access_token");
+
     console.log("[AXIOS TOKEN]", token);
 
     if (token) {
@@ -33,8 +51,6 @@ axiosInstance.interceptors.request.use(async (config) => {
   console.log("AXIOS REQUEST", {
     method: config.method,
     url: fullUrl,
-    params: config.params,
-    data: config.data,
     hasAuthHeader: !!(config.headers as any)?.Authorization,
   });
 
@@ -44,18 +60,24 @@ axiosInstance.interceptors.request.use(async (config) => {
 axiosInstance.interceptors.response.use(
   (response) => response,
   async (error) => {
+    const url = error?.config?.url ?? "";
+
     console.log("AXIOS ERROR", {
       status: error?.response?.status,
+      url,
       data: error?.response?.data,
-      message: error?.message,
-      method: error?.config?.method,
-      url: `${error?.config?.baseURL ?? ""}${error?.config?.url ?? ""}`,
-      params: error?.config?.params,
-      dataSent: error?.config?.data,
     });
 
-    if (error?.response?.status === 401) {
-      console.log("[AUTH] 401 발생 → 저장된 토큰 삭제");
+    const isJoinRequest = url.startsWith("/api/auth/join");
+    const isMeRequest = url.startsWith("/api/users/me");
+
+    if (
+      error?.response?.status === 401 &&
+      !isJoinRequest &&
+      !isMeRequest
+    ) {
+      console.log("[AUTH] 토큰 삭제");
+
       await SecureStore.deleteItemAsync("access_token");
       await SecureStore.deleteItemAsync("refresh_token");
     }


### PR DESCRIPTION
## 관련 이슈
- closes #32 

## 변경 요약
- 인증 흐름 및 온보딩/회원가입 로직 개선 및 마이페이지·설정 UI 구현

## 주요 작업 내용
- 카카오 로그인 이후 인증 흐름 수정
- /api/auth/join 요청 시 Authorization 헤더 누락 문제 해결
- 회원가입 → 프로필 셋업 → 홈 이동까지 전체 플로우 정상화
- /api/users/me 응답 기반으로 로그인 상태 판단 로직 개선 (회원정보 미입력 상태 분기 처리)
- 회원탈퇴 기능 구현 (DELETE /api/users/me) 및 탈퇴 후 토큰 초기화 + 온보딩 이동 처리
- 온보딩 재진입 시 자동 로그인으로 스킵되던 문제 수정
- 마이페이지 및 설정 화면 UI 구현 (보관된 여행/일기 관리 제외)
